### PR TITLE
Update installation config

### DIFF
--- a/doc/sphinx/release/release_notes.rst
+++ b/doc/sphinx/release/release_notes.rst
@@ -4,6 +4,18 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Added source for :arch-cpp:`align.h` which has been unintentionally
+        left out when building the ``arch`` library.
+
+    .. change:: fixed
+
+        Explicitly defined public headers so that private ones can be
+        easily omitted.
+
 .. release:: 0.3.2
     :date: 2023-07-12
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 
 add_library(arch
     arch/assumptions.cpp
+    arch/align.cpp
     arch/attributes.cpp
     arch/daemon.cpp
     arch/debugger.cpp
@@ -51,11 +52,39 @@ endif()
 
 install(TARGETS arch EXPORT ${PROJECT_NAME})
 install(
-    DIRECTORY
-        arch
+    FILES
+        arch/align.h
+        arch/api.h
+        arch/attributes.h
+        arch/buildMode.h
+        arch/daemon.h
+        arch/debugger.h
+        arch/defines.h
+        arch/demangle.h
+        arch/env.h
+        arch/errno.h
+        arch/error.h
+        arch/export.h
+        arch/fileSystem.h
+        arch/function.h
+        arch/functionLite.h
+        arch/hash.h
+        arch/hints.h
+        arch/inttypes.h
+        arch/library.h
+        arch/mallocHook.h
+        arch/math.h
+        arch/pragmas.h
+        arch/regex.h
+        arch/stackTrace.h
+        arch/symbols.h
+        arch/systemInfo.h
+        arch/threads.h
+        arch/timing.h
+        arch/virtualMemory.h
+        arch/vsnprintf.h
     DESTINATION
-        ${CMAKE_INSTALL_INCLUDEDIR}
-    FILES_MATCHING PATTERN "*.h"
+        ${CMAKE_INSTALL_INCLUDEDIR}/arch
 )
 
 install(EXPORT ${PROJECT_NAME}


### PR DESCRIPTION
- Declare `align.cpp` as a source when building the library, as it has been unintentionally left out.
- Explicitly define public headers so that private ones (e.g. `pch.h`) can be easily omitted.